### PR TITLE
Double the tag drop-down length in add photo page

### DIFF
--- a/src/components/TagInput.tsx
+++ b/src/components/TagInput.tsx
@@ -288,7 +288,7 @@ export default function TagInput({
             ref={optionsRef}
             className={clsx(
               'control absolute top-0 mt-3 w-full z-10 !px-1.5 !py-1.5',
-              'max-h-[8rem] overflow-y-auto',
+              'max-h-[16rem] overflow-y-auto',
               'flex flex-col gap-y-1',
               'text-xl shadow-lg dark:shadow-xl',
             )}


### PR DESCRIPTION
The size of the up-stream dropdown is far too small and is frustrating to use.
Doubling the size makes it far more tolerable  